### PR TITLE
IDs instead of hyperlinks for model relations

### DIFF
--- a/src/heimspiel/tests.py
+++ b/src/heimspiel/tests.py
@@ -20,7 +20,7 @@ class StoryTestCase(TestCase):
         # an authentication token, which will be encoded in a URL they can used
         # to play:
         user = self.post("/users/", {"name": "Heimspiel"})
-        self.assertTrue("url" in user)
+        self.assertTrue("id" in user)
         self.assertTrue("token" in user)
 
         # Set the Authorization header for future requests:
@@ -31,19 +31,18 @@ class StoryTestCase(TestCase):
         attributes = self.get("/playerattributes/")
         self.assertEqual(4, attributes["count"])
         self.assertEqual(
-            {"name": "Sportskanone", "url": "http://testserver/playerattributes/1/",},
-            attributes["results"][0],
+            {"name": "Sportskanone", "id": 1,}, attributes["results"][0],
         )
 
         # The group consists of two players: Alice and Bob. For each player the
         # clients post its name and attributes:
         alice = self.post(
             "/players/",
-            {"name": "Alice", "attributes": [attributes["results"][0]["url"]],},
+            {"name": "Alice", "attributes": [attributes["results"][0]["id"]],},
         )
         bob = self.post(
             "/players/",
-            {"name": "Bob", "attributes": [attributes["results"][1]["url"]],},
+            {"name": "Bob", "attributes": [attributes["results"][1]["id"]],},
         )
 
         # Let the game begin! The client will show available quests to the
@@ -53,8 +52,8 @@ class StoryTestCase(TestCase):
         self.assertEqual(2, quests["count"])
         self.assertEqual(
             {
-                "url": "http://testserver/quests/1/",
-                "category": "http://testserver/questcategories/chores/",
+                "id": 1,
+                "category": "chores",
                 "title": "Es war der Gärtner",
                 "text": (
                     "Gieße heimlich alle eure Pflanzen. Gib dich erst als "
@@ -76,7 +75,7 @@ class StoryTestCase(TestCase):
         self.assertEqual(6, categories["count"])
         self.assertEqual(
             {
-                "url": "http://testserver/questcategories/activity/",
+                "id": "activity",
                 "title": "Beschäftigung",
                 "image": "http://testserver/media/filer_public/c3/1f/c31f700d-fb3d-45d3-b293-ca35ca324b5f/activity.jpg",
             },
@@ -89,16 +88,16 @@ class StoryTestCase(TestCase):
                 "date": "2020-03-22T17:00:00Z",
                 "report": [
                     {
-                        "player": alice["url"],
+                        "player": alice["id"],
                         "category_scores": [
-                            {"category": categories["results"][0]["url"], "score": 42},
-                            {"category": categories["results"][3]["url"], "score": 2},
+                            {"category": categories["results"][0]["id"], "score": 42},
+                            {"category": categories["results"][3]["id"], "score": 2},
                         ],
                     },
                     {
-                        "player": bob["url"],
+                        "player": bob["id"],
                         "category_scores": [
-                            {"category": categories["results"][0]["url"], "score": 10},
+                            {"category": categories["results"][0]["id"], "score": 10},
                         ],
                     },
                 ],
@@ -107,8 +106,8 @@ class StoryTestCase(TestCase):
         self.assertEqual(
             {
                 "players": [
-                    {"player": "http://testserver/players/Alice/", "score": 44},
-                    {"player": "http://testserver/players/Bob/", "score": 10},
+                    {"player": alice["id"], "score": 44},
+                    {"player": bob["id"], "score": 10},
                 ],
                 "user": 54,
             },
@@ -117,9 +116,9 @@ class StoryTestCase(TestCase):
         self.assertEqual([], result["earned_badges"]["user"])
 
         # Retrieving the players will also contain their updated scores:
-        alice = self.get(alice["url"])
+        alice = self.get(f"/players/{alice['id']}/")
         self.assertEqual(44, alice["score"])
-        bob = self.get(bob["url"])
+        bob = self.get(f"/players/{bob['id']}/")
         self.assertEqual(10, bob["score"])
 
     def get(self, url):

--- a/src/heimspiel_auth/serializers.py
+++ b/src/heimspiel_auth/serializers.py
@@ -6,10 +6,10 @@ from rest_framework.authtoken.models import Token
 from .models import User
 
 
-class UserSerializer(serializers.HyperlinkedModelSerializer):
+class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ["url", "id", "name"]
+        fields = ["id", "name"]
 
     def create(self, validated_data):
         validated_data["id"] = uuid.uuid4()

--- a/src/heimspiel_core/score.py
+++ b/src/heimspiel_core/score.py
@@ -29,16 +29,12 @@ class UserScoreReport:
 
 
 class CategoryScoreReportSerializer(serializers.Serializer):
-    category = serializers.HyperlinkedRelatedField(
-        queryset=QuestCategory.objects.all(), view_name="questcategory-detail"
-    )
+    category = serializers.PrimaryKeyRelatedField(queryset=QuestCategory.objects.all())
     score = serializers.IntegerField()
 
 
 class PlayerScoreReportSerializer(serializers.Serializer):
-    player = serializers.HyperlinkedRelatedField(
-        queryset=Player.objects.all(), view_name="player-detail"
-    )
+    player = serializers.PrimaryKeyRelatedField(queryset=Player.objects.all())
     category_scores = CategoryScoreReportSerializer(many=True)
 
 

--- a/src/heimspiel_core/serializers.py
+++ b/src/heimspiel_core/serializers.py
@@ -12,39 +12,39 @@ class GetImageMixin:
             return None
 
 
-class PlayerSerializer(serializers.HyperlinkedModelSerializer):
+class PlayerSerializer(serializers.ModelSerializer):
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())
 
     class Meta:
         model = Player
-        fields = ["url", "user", "name", "score", "background_story", "attributes"]
+        fields = ["id", "user", "name", "score", "background_story", "attributes"]
 
 
-class PlayerAttributeSerializer(serializers.HyperlinkedModelSerializer):
+class PlayerAttributeSerializer(serializers.ModelSerializer):
     class Meta:
         model = PlayerAttribute
-        fields = ["url", "name"]
+        fields = ["id", "name"]
 
 
-class QuestSerializer(serializers.HyperlinkedModelSerializer, GetImageMixin):
+class QuestSerializer(serializers.ModelSerializer, GetImageMixin):
     image = serializers.SerializerMethodField()
 
     class Meta:
         model = Quest
-        fields = ["url", "title", "category", "text", "flavor_text", "score", "image"]
+        fields = ["id", "title", "category", "text", "flavor_text", "score", "image"]
 
 
-class QuestCategorySerializer(serializers.HyperlinkedModelSerializer, GetImageMixin):
+class QuestCategorySerializer(serializers.ModelSerializer, GetImageMixin):
     image = serializers.SerializerMethodField()
 
     class Meta:
         model = QuestCategory
-        fields = ["url", "title", "image"]
+        fields = ["id", "title", "image"]
 
 
-class BadgeSerializer(serializers.HyperlinkedModelSerializer, GetImageMixin):
+class BadgeSerializer(serializers.ModelSerializer, GetImageMixin):
     image = serializers.SerializerMethodField()
 
     class Meta:
         model = Badge
-        fields = ["url", "name", "image"]
+        fields = ["id", "name", "image"]

--- a/src/heimspiel_core/views.py
+++ b/src/heimspiel_core/views.py
@@ -70,10 +70,7 @@ def score_reports(request):
             player.score += c["score"]
         player.save()
         player_scores.append(
-            {
-                "player": reverse("player-detail", args=[player], request=request),
-                "score": player.score,
-            }
+            {"player": player.id, "score": player.score,}
         )
         user_score += player.score
 


### PR DESCRIPTION
As discussed yesterday we remove hyperlinks for displaying model relations in favor of plain IDs. There are mainly two reasons for this:

- The frontend will hardcode at least the quest categories' ids to attach custom styles to them. URL make this more cumbersome than necessary.
- Using URLs instead of IDs makes it harder to move the backend to another domain, which will actually happen soon (#15).

@normade If you're fine with this, you can merge and deploy it already. @Twissi is waiting for it, afaik :-).